### PR TITLE
Fix torpedo names

### DIFF
--- a/Detailed Turret Tooltips/data/scripts/lib/tooltipmaker.lua
+++ b/Detailed Turret Tooltips/data/scripts/lib/tooltipmaker.lua
@@ -995,7 +995,9 @@ function makeTorpedoTooltip(torpedo)
     local tooltip = Tooltip()
     tooltip.icon = torpedo.icon
 
-	fillObjectTooltipHeader(torpedo, tooltip, torpedo.name, true, "torpedo")
+	local torpedo_name = torpedo.name%_t % {warhead = torpedo.warheadClass%_t, speed = torpedo.bodyClass%_t}
+
+	fillObjectTooltipHeader(torpedo, tooltip, torpedo_name, true, "torpedo")
 
     if torpedo.hullDamage > 0 and torpedo.damageVelocityFactor == 0 then
         local line = TooltipLine(lineHeight, fontSize)


### PR DESCRIPTION
Torpedo names were showing up with string placeholders in them for warhead and speed classes. This seems to fix the issue for me